### PR TITLE
Not using BluetoothSocket#isConnected() 

### DIFF
--- a/src/android/BluetoothWrapper.java
+++ b/src/android/BluetoothWrapper.java
@@ -553,6 +553,7 @@ public class BluetoothWrapper
 					synchronized(_socket)
 					{
 						_socket.close();
+                        _socket = null;
 					}
 				}
 			}


### PR DESCRIPTION
Instead of depending on the implementation of isConnected() method, we assume the connection is ok, when the socket is not null. Writing or reading from a closed/not connected socket will trigger an error like normal. 
This is done because isConnected() always returns false on some devices. 
